### PR TITLE
fix: Cache install hooks in earlier layer

### DIFF
--- a/dagger/precommit/dagger.go
+++ b/dagger/precommit/dagger.go
@@ -8,8 +8,19 @@ import (
 	"dagger.io/dagger"
 )
 
+const (
+	precommitConfigFileName              = ".pre-commit-config.yaml"
+	precommitInstallHooksDir             = "/tmp/install-pre-commit-hooks/"
+	precommitInstallHooksMountConfigFile = precommitInstallHooksDir + precommitConfigFileName
+)
+
 func Run(ctx context.Context, client *dagger.Client, workdir *dagger.Directory) error {
 	srcDirID, err := workdir.ID(ctx)
+	if err != nil {
+		return err
+	}
+	precommitConfigFile := workdir.File(precommitConfigFileName)
+	precommitConfigFileID, err := precommitConfigFile.ID(ctx)
 	if err != nil {
 		return err
 	}
@@ -17,7 +28,6 @@ func Run(ctx context.Context, client *dagger.Client, workdir *dagger.Directory) 
 	// Create a pre-commit container
 	container := client.
 		Container().From("python:3.12.0a1-bullseye").
-		WithMountedDirectory("/src", srcDirID).WithWorkdir("/src").
 		Exec(dagger.ContainerExecOpts{
 			Args: []string{
 				"curl",
@@ -26,12 +36,20 @@ func Run(ctx context.Context, client *dagger.Client, workdir *dagger.Directory) 
 				"https://github.com/pre-commit/pre-commit/releases/download/v2.20.0/pre-commit-2.20.0.pyz",
 			},
 		}).
+		WithMountedFile(precommitInstallHooksMountConfigFile, precommitConfigFileID).WithWorkdir(precommitInstallHooksDir).
+		Exec(dagger.ContainerExecOpts{
+			Args: []string{
+				"git", "init",
+			},
+		}).
 		Exec(dagger.ContainerExecOpts{
 			Args: []string{
 				"python", "/usr/local/bin/pre-commit-2.20.0.pyz",
 				"install-hooks",
 			},
 		}).
+		WithoutMount(precommitInstallHooksMountConfigFile).
+		WithMountedDirectory("/src", srcDirID).WithWorkdir("/src").
 		Exec(dagger.ContainerExecOpts{
 			Args: []string{
 				"python", "/usr/local/bin/pre-commit-2.20.0.pyz",

--- a/dagger/precommit/options.go
+++ b/dagger/precommit/options.go
@@ -1,0 +1,20 @@
+package precommit
+
+type config struct {
+	baseImage string
+}
+
+func defaultConfig() config {
+	return config{
+		baseImage: "python:3.12.0a1-bullseye",
+	}
+}
+
+type Option func(config) config
+
+func BaseImage(img string) Option {
+	return func(c config) config {
+		c.baseImage = img
+		return c
+	}
+}

--- a/mage/precommit/mage.go
+++ b/mage/precommit/mage.go
@@ -9,7 +9,14 @@ import (
 	precommitDagger "github.com/aweris/tools/dagger/precommit"
 )
 
+const (
+	baseImageEnvVar = "PRECOMMIT_BASE_IMAGE"
+)
+
 // Precommit runs all the precommit checks.
+// Configurable via the following environment variables:
+//
+//	PRECOMMIT_BASE_IMAGE - The base image to run pre-commit in.
 func Precommit(ctx context.Context) error {
 	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
 	if err != nil {
@@ -17,5 +24,11 @@ func Precommit(ctx context.Context) error {
 	}
 	defer client.Close()
 
-	return precommitDagger.Run(ctx, client, client.Host().Workdir().Read())
+	var opts []precommitDagger.Option
+
+	if baseImage, ok := os.LookupEnv(baseImageEnvVar); ok {
+		opts = append(opts, precommitDagger.BaseImage(baseImage))
+	}
+
+	return precommitDagger.Run(ctx, client, client.Host().Workdir().Read(), opts...)
 }

--- a/utils/hash.go
+++ b/utils/hash.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+)
+
+func SHA256SumFile(file string) (string, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return "", fmt.Errorf("failed to open file %q: %w", file, err)
+	}
+
+	h := sha256.New()
+
+	if _, err := io.Copy(h, f); err != nil {
+		return "", fmt.Errorf("failed to create sha256 sum of file %q: %w", file, err)
+	}
+
+	return hex.EncodeToString(h.Sum(nil)), nil
+}


### PR DESCRIPTION
Previously any change to the src dir would have invalidated cache layers, meaning that pre-commit hooks need to be reinstalled every run. This caches just the pre-commit hooks in a previous layer so they are only updated when the pre-commit config file changes.