### PR TITLE
feat: Enable further configuration options

### DIFF
--- a/dagger/options/container_customizer.go
+++ b/dagger/options/container_customizer.go
@@ -1,0 +1,59 @@
+package options
+
+import (
+	"context"
+
+	"dagger.io/dagger"
+)
+
+type ContainerCustomizer func(*dagger.Container) (*dagger.Container, error)
+
+func AppendToPATH(ctx context.Context, dir string) ContainerCustomizer {
+	return func(c *dagger.Container) (*dagger.Container, error) {
+		existingPATH, err := c.EnvVariable(ctx, "PATH")
+		if err != nil {
+			return nil, err
+		}
+		return c.WithEnvVariable("PATH", existingPATH+":/usr/local/go/bin"), nil
+	}
+}
+
+func InstallGo(ctx context.Context) ContainerCustomizer {
+	return func(c *dagger.Container) (*dagger.Container, error) {
+		c = c.Exec(dagger.ContainerExecOpts{
+			Args: []string{
+				"bash", "-ec",
+				`curl --location --fail --silent --show-error https://go.dev/dl/go1.19.3.linux-amd64.tar.gz |
+				tar -C /usr/local -xz`,
+			},
+		})
+		return AppendToPATH(ctx, "/usr/local/go/bin")(c)
+	}
+}
+
+func DownloadFile(ctx context.Context, url, destFile string) ContainerCustomizer {
+	return func(c *dagger.Container) (*dagger.Container, error) {
+		return c.Exec(dagger.ContainerExecOpts{
+			Args: []string{
+				"curl",
+				"--location", "--fail", "--silent", "--show-error",
+				"--output", destFile,
+				url,
+			},
+		}), nil
+	}
+}
+
+func DownloadExecutableFile(ctx context.Context, url, destFile string) ContainerCustomizer {
+	return func(c *dagger.Container) (*dagger.Container, error) {
+		c, err := DownloadFile(ctx, url, destFile)(c)
+		if err != nil {
+			return nil, err
+		}
+		return c.Exec(dagger.ContainerExecOpts{
+			Args: []string{
+				"chmod", "755", destFile,
+			},
+		}), nil
+	}
+}

--- a/dagger/precommit/dagger.go
+++ b/dagger/precommit/dagger.go
@@ -38,15 +38,20 @@ func Run(ctx context.Context, client *dagger.Client, workdir *dagger.Directory, 
 
 	// Create a pre-commit container
 	container := client.
-		Container().From(cfg.baseImage).
-		Exec(dagger.ContainerExecOpts{
-			Args: []string{
-				"curl",
-				"--location", "--fail", "--silent", "--show-error",
-				"--output", "/usr/local/bin/pre-commit-2.20.0.pyz",
-				"https://github.com/pre-commit/pre-commit/releases/download/v2.20.0/pre-commit-2.20.0.pyz",
-			},
-		}).
+		Container().From(cfg.baseImage)
+
+	for _, c := range cfg.containerCustomizers {
+		container = c(container)
+	}
+
+	container = container.Exec(dagger.ContainerExecOpts{
+		Args: []string{
+			"curl",
+			"--location", "--fail", "--silent", "--show-error",
+			"--output", "/usr/local/bin/pre-commit-2.20.0.pyz",
+			"https://github.com/pre-commit/pre-commit/releases/download/v2.20.0/pre-commit-2.20.0.pyz",
+		},
+	}).
 		WithEnvVariable(precommitHomeEnvVar, cacheDir).
 		WithMountedCache(cacheID, cacheDir).
 		WithMountedDirectory("/src", srcDirID).WithWorkdir("/src").

--- a/dagger/precommit/options.go
+++ b/dagger/precommit/options.go
@@ -1,10 +1,10 @@
 package precommit
 
-import "dagger.io/dagger"
+import "github.com/aweris/tools/dagger/options"
 
 type config struct {
 	baseImage            string
-	containerCustomizers []ContainerCustomizer
+	containerCustomizers []options.ContainerCustomizer
 }
 
 func defaultConfig() config {
@@ -15,8 +15,6 @@ func defaultConfig() config {
 
 type Option func(config) config
 
-type ContainerCustomizer func(*dagger.Container) *dagger.Container
-
 func BaseImage(img string) Option {
 	return func(c config) config {
 		c.baseImage = img
@@ -24,7 +22,7 @@ func BaseImage(img string) Option {
 	}
 }
 
-func CustomizeContainer(customizers ...ContainerCustomizer) Option {
+func CustomizeContainer(customizers ...options.ContainerCustomizer) Option {
 	return func(c config) config {
 		c.containerCustomizers = append(c.containerCustomizers, customizers...)
 		return c

--- a/dagger/precommit/options.go
+++ b/dagger/precommit/options.go
@@ -1,7 +1,10 @@
 package precommit
 
+import "dagger.io/dagger"
+
 type config struct {
-	baseImage string
+	baseImage            string
+	containerCustomizers []ContainerCustomizer
 }
 
 func defaultConfig() config {
@@ -12,9 +15,18 @@ func defaultConfig() config {
 
 type Option func(config) config
 
+type ContainerCustomizer func(*dagger.Container) *dagger.Container
+
 func BaseImage(img string) Option {
 	return func(c config) config {
 		c.baseImage = img
+		return c
+	}
+}
+
+func CustomizeContainer(customizers ...ContainerCustomizer) Option {
+	return func(c config) config {
+		c.containerCustomizers = append(c.containerCustomizers, customizers...)
 		return c
 	}
 }

--- a/mage/precommit/mage.go
+++ b/mage/precommit/mage.go
@@ -6,7 +6,7 @@ import (
 
 	"dagger.io/dagger"
 
-	precommitDagger "github.com/aweris/tools/dagger/precommit"
+	precommitdagger "github.com/aweris/tools/dagger/precommit"
 )
 
 const (
@@ -24,11 +24,26 @@ func Precommit(ctx context.Context) error {
 	}
 	defer client.Close()
 
-	var opts []precommitDagger.Option
+	var opts []precommitdagger.Option
 
 	if baseImage, ok := os.LookupEnv(baseImageEnvVar); ok {
-		opts = append(opts, precommitDagger.BaseImage(baseImage))
+		opts = append(opts, precommitdagger.BaseImage(baseImage))
 	}
 
-	return precommitDagger.Run(ctx, client, client.Host().Workdir().Read(), opts...)
+	return precommitdagger.Run(ctx, client, client.Host().Workdir().Read(), opts...)
+}
+
+// PrecommitWithOptions runs all the precommit checks with Dagger options.
+func PrecommitWithOptions(ctx context.Context, opts ...precommitdagger.Option) error {
+	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
+	if err != nil {
+		panic(err)
+	}
+	defer client.Close()
+
+	if baseImage, ok := os.LookupEnv(baseImageEnvVar); ok {
+		opts = append([]precommitdagger.Option{precommitdagger.BaseImage(baseImage)}, opts...)
+	}
+
+	return precommitdagger.Run(ctx, client, client.Host().Workdir().Read(), opts...)
 }


### PR DESCRIPTION
This commit enables further configuration of the dagger container by
allowing project's magefiles to run commands against the pre-commit
container before the pre-commit task is run.

Some customizers are provided out of the box, namely install go,
download file, and download executable file.

As an example, this is used
in mindthegap in the following way to install go and shfmt, both of
which are required for the pre-commit checks in that repository:

```go
package main

import (
	"context"

	"github.com/aweris/tools/dagger/options"
	precommitdagger "github.com/aweris/tools/dagger/precommit"
	"github.com/aweris/tools/mage/precommit"
	_ "github.com/magefile/mage/mage"
	"github.com/magefile/mage/mg"
)

type Lint mg.Namespace

func (Lint) Precommit(ctx context.Context) error {
	return precommit.PrecommitWithOptions(ctx,
		precommitdagger.CustomizeContainer(
			options.DownloadExecutableFile(
				ctx,
				"https://github.com/mvdan/sh/releases/download/v3.5.1/shfmt_v3.5.1_linux_amd64",
				"/usr/local/bin/shfmt",
			),
			options.InstallGo(ctx),
		),
	)
}
```
